### PR TITLE
 fix forcedefault options ignores 'n' issue

### DIFF
--- a/src/TwigGravatar.php
+++ b/src/TwigGravatar.php
@@ -95,8 +95,11 @@ class TwigGravatar extends \Twig_Extension {
 		}
 		else {
 			if (filter_var($default, FILTER_VALIDATE_URL)) $default = urlencode($default);
-			$force = ($force ? "y" : "n");
-			return $this->query($value, array("default" => $default, "forcedefault" => $force));
+                        $addition = array("default" => $default);
+                        if ($force) {
+                            $addition["forcedefault"] = 'y';
+                        }
+			return $this->query($value, $addition);
 		}
 	}
 

--- a/tests/TwigGravatarTest.php
+++ b/tests/TwigGravatarTest.php
@@ -85,9 +85,19 @@ class TwigGravatarTest extends \PHPUnit_Framework_TestCase{
 		$this->assertEquals(sizeof($Sizes), $ExceptionCount);
 	}
 
-	public function testDef(){
+	public function testDefWithForcedValueTrue(){
+		$Defaulted = $this->TwigGravatar->def($this->Url, "blank", true);
+		$this->assertEquals($this->Url."?default=blank&forcedefault=y", $Defaulted);
+	}
+
+	public function testDefWithForcedValueFalse(){
+		$Defaulted = $this->TwigGravatar->def($this->Url, "blank", false);
+		$this->assertEquals($this->Url."?default=blank", $Defaulted);
+	}
+
+	public function testDefWithoutForcedValue(){
 		$Defaulted = $this->TwigGravatar->def($this->Url, "blank");
-		$this->assertEquals($this->Url."?default=blank&forcedefault=n", $Defaulted);
+		$this->assertEquals($this->Url."?default=blank", $Defaulted);
 	}
 
 	public function testInvalidDef(){


### PR DESCRIPTION
https://secure.gravatar.com/avatar/725336b62b44a44ace2f31fd2333d1f5?size=300
https://secure.gravatar.com/avatar/725336b62b44a44ace2f31fd2333d1f5?size=300&f=y
https://secure.gravatar.com/avatar/725336b62b44a44ace2f31fd2333d1f5?size=300&f=n
https://secure.gravatar.com/avatar/725336b62b44a44ace2f31fd2333d1f5?size=300&forcedefault=y
https://secure.gravatar.com/avatar/725336b62b44a44ace2f31fd2333d1f5?size=300&forcedefault=n

When setting f or forcedefault then its always evaluated as true by gravatar. Didn't found an issue tracker for gravatar and code change isn't wrong as all. So I opened a PR here.