### PR TITLE
Allow set of default values in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,45 +9,55 @@ An extension for Twig that provides simple filters for Gravatar.
 
 ## Installation
 Use `composer` to install this extension:
-```
+```Shell
 composer require ry167/twig-gravatar 2.0.2
 ```
 
 ## Usage
-```
+```PHP
 require("vendor/autoload.php");
 
 //Define your Twig Environment and Twig Loader
 $twig->addExtension(new \TwigGravatar());
+
+//create customized Twig Gravatar
+new \TwigGravatar($default = null, $size = null, $filterPrefix = 'gr', $rating = null, $useHttps = true);
 ```
 
 ## Usage in Symfony
-```
+```YAML
     twig.extension.gravatar:
         class: \TwigGravatar
+        arguments:
+            $default: ~         e.g. 'monsterid'
+            $size: ~            e.g. 50
+            $filterPrefix: ~    e.g. 'foo'
+            $rating: ~          e.g. 'x'
+            $useHttps: true
         tags:
             - { name: twig.extension }
 ```
+You can also remove arguments section and the default values shown will be used.
 
 ## Filters
 This is Extension is designed so that you chain together the filters that you need on top of each other. You must however always start with the grAvatar filter.
 
 ### grAvatar
 Create a Gravatar URL, This returns just the URL for the persons avatar image without the `<img>` tag
-```
-{{example@example.com|grAvatar}}
+```Twig
+{{ 'example@example.com'|grAvatar }}
 ```
 
 ### grHttps
 Change a Gravatar URL to its secure counterpart.
-```
-{example@example.com|grAvatar|grHttps}
+```Twig
+{{ 'example@example.com'|grAvatar|grHttps }}
 ```
 
 ### grSize
 Change the Size of the Gravatar Image to the specified size in pixels.
-```
-{{example@example.com|grAvatar|grSize(1024)}}
+```Twig
+{{ 'example@example.com'|grAvatar|grSize(1024) }}
 ```
 
 Gravatar does not serve images greater than `2048px`, and they are all squares.
@@ -55,7 +65,7 @@ Gravatar does not serve images greater than `2048px`, and they are all squares.
 ### grDefault
 Specify a default image for if the User does not have one defined
 ```
-{{example@example.com|grAvatar|grDefault('http://example.com/default.png')}}
+{{ 'example@example.com'|grAvatar|grDefault('http://example.com/default.png') }}
 ```
 
 You can also use any of Gravatar's built in default images, [you can see them here](http://en.gravatar.com/site/implement/images/# default-image). Just use the code assigned to them such as `mm` instead of your Image URL.
@@ -64,16 +74,15 @@ You can also use any of Gravatar's built in default images, [you can see them he
 Specify a maximum rating that the image can be.
 Valid values are `g,pg,r` and `x`.
 ```
-{{example@example.com|grAvatar|grRating('pg')}}
+{{ 'example@example.com'|grAvatar|grRating('pg') }}
 ```
 
 ## Prefix
-You can change the filter prefix from `gr` to something else by editing its public variable.
-```
+You can change the filter prefix from `gr` to something else by changing its value in constructor.
+```PHP
 //Define your Twig Environment and Twig Loader
 
-$TwigGravatar = new \TwigGravatar();
-$TwigGravatar->filterPrefix = 'foo';
+$TwigGravatar = new \TwigGravatar(null, null, 'foo');
 
 $twig->addExtension($TwigGravatar);
 //Filters are now 'fooAvatar' etc

--- a/tests/TwigGravatarConstructorTest.php
+++ b/tests/TwigGravatarConstructorTest.php
@@ -1,0 +1,109 @@
+<?php
+class TwigGravatarConstructorTest extends \PHPUnit_Framework_TestCase{
+
+	protected $email;
+	protected $hash;
+	protected $url;
+	protected $secureUrl;
+
+	public function setUp(){
+		$this->email = "example@example.com";
+		$this->hash = "23463b99b62a72f26ed677cc556c44e8";
+		$this->url = "http://www.gravatar.com/avatar/".$this->hash;
+		$this->secureUrl = "https://secure.gravatar.com/avatar/".$this->hash;
+	}
+
+	public function testDefault(){
+		$twigGravatar = new \TwigGravatar('retro');
+
+		$defaulted = $twigGravatar->avatar($this->email);
+		$this->assertEquals($this->secureUrl."?default=retro", $defaulted);
+
+		$defaulted = $twigGravatar->def($this->url, "mm");
+		$this->assertEquals($this->url."?default=mm", $defaulted);
+	}
+
+	public function testSize(){
+		$twigGravatar = new \TwigGravatar(null, 50);
+
+		$sized = $twigGravatar->avatar($this->email);
+		$this->assertEquals($this->secureUrl."?size=50", $sized);
+
+		$sized = $twigGravatar->size($this->url, 100);
+		$this->assertEquals($this->url."?size=100", $sized);
+	}
+
+	public function testFilterPrefixIsSetToSm(){
+		$twigGravatar = new \TwigGravatar(null, null, 'sm');
+
+		$filterNames = array();
+		$filters = $twigGravatar->getFilters();
+
+		/** @var Twig_SimpleFilter $twigSimpleFilter */
+		foreach ($filters as $twigSimpleFilter) {
+			$filterNames[] = $twigSimpleFilter->getName();
+		}
+
+		$this->assertContains('smAvatar',$filterNames);
+		$this->assertContains('smHttps',$filterNames);
+		$this->assertContains('smSize',$filterNames);
+		$this->assertContains('smDefault',$filterNames);
+		$this->assertContains('smRating',$filterNames);
+
+		$this->assertNotContains('grAvatar',$filterNames);
+		$this->assertNotContains('grHttps',$filterNames);
+		$this->assertNotContains('grSize',$filterNames);
+		$this->assertNotContains('grDefault',$filterNames);
+		$this->assertNotContains('grRating',$filterNames);
+	}
+
+	public function testRating(){
+		$twigGravatar = new \TwigGravatar(null, null, null, 'x');
+
+		$rated = $twigGravatar->avatar($this->email);
+		$this->assertEquals($this->secureUrl."?rating=x", $rated);
+
+		$rated = $twigGravatar->rating($this->url, "r");
+		$this->assertEquals($this->url."?rating=r", $rated);
+	}
+
+	public function testUseHttpsIsFalse(){
+		$twigGravatar = new \TwigGravatar(null, null, null, null, false);
+
+		$unsecureUrl = $twigGravatar->avatar($this->email);
+		$this->assertEquals($this->url, $unsecureUrl);
+
+		$secureUrl = $twigGravatar->https($this->url);
+		$this->assertEquals($this->secureUrl, $secureUrl);
+	}
+
+	public function testUseHttpsIsTrue(){
+		$twigGravatar = new \TwigGravatar(null, null, null, null, true);
+
+		$secureUrl = $twigGravatar->https($this->url);
+		$this->assertEquals($this->secureUrl, $secureUrl);
+	}
+
+	public function testChaining(){
+		$twigGravatar = new \TwigGravatar('blank', 200, 'sm', 'x', true);
+
+		$secureUrl = $twigGravatar->avatar($this->email);
+		$this->assertEquals($this->secureUrl.'?rating=x&size=200&default=blank', $secureUrl);
+
+		$secureUrl = $twigGravatar->avatar($this->email);
+		$secureUrl = $twigGravatar->rating($secureUrl, 'r');
+		$this->assertEquals($this->secureUrl.'?rating=r&size=200&default=blank', $secureUrl);
+
+		$secureUrl = $twigGravatar->avatar($this->email);
+		$secureUrl = $twigGravatar->rating($secureUrl, 'r');
+		$secureUrl = $twigGravatar->def($secureUrl, 'monsterid');
+		$secureUrl = $twigGravatar->size($secureUrl, '20');
+		$this->assertEquals($this->secureUrl.'?rating=r&size=20&default=monsterid', $secureUrl);
+
+		$secureUrl = $twigGravatar->avatar($this->email);
+		$secureUrl = $twigGravatar->def($secureUrl, 'monsterid', true);
+		$secureUrl = $twigGravatar->size($secureUrl, '20');
+		$secureUrl = $twigGravatar->rating($secureUrl, 'r');
+		$this->assertEquals($this->secureUrl.'?rating=r&size=20&default=monsterid&forcedefault=y', $secureUrl);
+	}
+}

--- a/tests/TwigGravatarTest.php
+++ b/tests/TwigGravatarTest.php
@@ -1,150 +1,156 @@
 <?php
 class TwigGravatarTest extends \PHPUnit_Framework_TestCase{
-	protected $TwigGravatar;
+	/** @var TwigGravatar */
+	protected $twigGravatar;
 
-	protected $Email;
-	protected $Hash;
-	protected $Url;
-	protected $SecureUrl;
+	protected $email;
+	protected $hash;
+	protected $url;
+	protected $secureUrl;
 
 	public function setUp(){
-		$this->TwigGravatar = new \TwigGravatar();
+		$this->twigGravatar = new \TwigGravatar();
 
-		$this->Email = "example@example.com";
-		$this->Hash = "23463b99b62a72f26ed677cc556c44e8";
-		$this->Url = "http://www.gravatar.com/avatar/".$this->Hash;
-		$this->SecureUrl = "https://secure.gravatar.com/avatar/".$this->Hash;
+		$this->email = "example@example.com";
+		$this->hash = "23463b99b62a72f26ed677cc556c44e8";
+		$this->url = "http://www.gravatar.com/avatar/".$this->hash;
+		$this->secureUrl = "https://secure.gravatar.com/avatar/".$this->hash;
 	}
 
 	public function tearDown(){}
 
 	public function testGetFilters(){
 		$filterNames = array();
-		$filters = $this->TwigGravatar->getFilters();
-		
+		$filters = $this->twigGravatar->getFilters();
+
+		/** @var Twig_SimpleFilter $twigSimpleFilter */
 		foreach ($filters as $twigSimpleFilter) {
 			$filterNames[] = $twigSimpleFilter->getName();
 		}
 
- 
-		$this->assertContains('grAvatar',$filterNames);
-		$this->assertContains('grHttps',$filterNames);
-		$this->assertContains('grSize',$filterNames);
-		$this->assertContains('grDefault',$filterNames);
-		$this->assertContains('grRating',$filterNames);
+		$this->assertContains('grAvatar', $filterNames);
+		$this->assertContains('grHttps', $filterNames);
+		$this->assertContains('grSize', $filterNames);
+		$this->assertContains('grDefault', $filterNames);
+		$this->assertContains('grRating', $filterNames);
 	}
 
 	public function testAvatar(){
-		$Avatar = $this->TwigGravatar->avatar($this->Email);
-		$this->assertEquals($this->Url, $Avatar);
+		$avatar = $this->twigGravatar->avatar($this->email);
+		$this->assertEquals($this->secureUrl, $avatar);
 	}
 
 	public function testInvalidAvatar(){
 		$this->setExpectedException("InvalidArgumentException");
-		$Avatar = $this->TwigGravatar->avatar("invalid@@email..com");
+		$avatar = $this->twigGravatar->avatar("invalid@@email..com");
 	}
 
 	public function testHttps(){
-		$SecureUrl = $this->TwigGravatar->https($this->Url);
-		$this->assertEquals($this->SecureUrl, $SecureUrl);
+		$secureUrl = $this->twigGravatar->https($this->url);
+		$this->assertEquals($this->secureUrl, $secureUrl);
 	}
 
 	public function testInvalidUrl(){
-		$InvalidUrl = "http://not.gravatar.at.all";
-		$Functions = array('https','size','def','rating');
-		$ExceptionCount = 0;
+		$invalidUrl = "http://not.gravatar.at.all";
+		$functions = array(
+			'https' => null,
+			'size' => 20,
+			'def' => null,
+			'rating' => 'r'
+		);
+		$exceptionCount = 0;
 
-		foreach ($Functions as $function){
+		foreach ($functions as $function => $argument){
 			try{
-				$this->TwigGravatar->$function($InvalidUrl);
+				$this->twigGravatar->$function($invalidUrl, $argument);
 			} catch (Exception $e){
-				$ExceptionCount++;
+				$exceptionCount++;
 				$this->assertContains("existing Gravatar URL", $e->getMessage());
 			}
 		}
-		$this->assertEquals(sizeof($Functions), $ExceptionCount);
+		$this->assertEquals(sizeof($functions), $exceptionCount);
 	}
 
 	public function testSize(){
-		$Sized = $this->TwigGravatar->size($this->Url, 100);
-		$this->assertEquals($this->Url."?size=100", $Sized);
+		$sized = $this->twigGravatar->size($this->url, 100);
+		$this->assertEquals($this->url."?size=100", $sized);
 	}
 
 	public function testInvalidSize(){
-		$Sizes = array("abc", -1, 3000);
-		$ExceptionCount = 0;
+		$sizes = array("abc", -1, 3000);
+		$exceptionCount = 0;
 
-		foreach ($Sizes as $size){
+		foreach ($sizes as $size){
 			try{
-				echo $this->TwigGravatar->size($this->Url, $size);
+				echo $this->twigGravatar->size($this->url, $size);
 			} catch (InvalidArgumentException $e){
-				$ExceptionCount++;
+				$exceptionCount++;
 				$this->assertEquals("You must pass the size filter a valid number between 0 and 2048", $e->getMessage());
 			}
 		}
-		$this->assertEquals(sizeof($Sizes), $ExceptionCount);
+		$this->assertEquals(sizeof($sizes), $exceptionCount);
 	}
 
 	public function testDefWithForcedValueTrue(){
-		$Defaulted = $this->TwigGravatar->def($this->Url, "blank", true);
-		$this->assertEquals($this->Url."?default=blank&forcedefault=y", $Defaulted);
+		$defaulted = $this->twigGravatar->def($this->url, "blank", true);
+		$this->assertEquals($this->url."?default=blank&forcedefault=y", $defaulted);
 	}
 
 	public function testDefWithForcedValueFalse(){
-		$Defaulted = $this->TwigGravatar->def($this->Url, "blank", false);
-		$this->assertEquals($this->Url."?default=blank", $Defaulted);
+		$defaulted = $this->twigGravatar->def($this->url, "blank", false);
+		$this->assertEquals($this->url."?default=blank", $defaulted);
 	}
 
 	public function testDefWithoutForcedValue(){
-		$Defaulted = $this->TwigGravatar->def($this->Url, "blank");
-		$this->assertEquals($this->Url."?default=blank", $Defaulted);
+		$defaulted = $this->twigGravatar->def($this->url, "blank");
+		$this->assertEquals($this->url."?default=blank", $defaulted);
 	}
 
 	public function testInvalidDef(){
-		$ExceptionCount = 0;
+		$exceptionCount = 0;
 
 		try{
-			$this->TwigGravatar->def($this->Url, "thisisnotanavatarorurl");
+			$this->twigGravatar->def($this->url, "thisisnotanavatarorurl");
 		} catch (InvalidArgumentException $e){
-			$ExceptionCount++;
+			$exceptionCount++;
 			$this->assertEquals('Default must be a URL or valid default', $e->getMessage());
 		}
 
 		try{
-			$this->TwigGravatar->def($this->Url, "blank", "probably");
+			$this->twigGravatar->def($this->url, "blank", "probably");
 		} catch (InvalidArgumentException $e){
-			$ExceptionCount++;
+			$exceptionCount++;
 			$this->assertEquals("The force option for a default must be boolean", $e->getMessage());
 		}
 
-		$this->assertEquals(2, $ExceptionCount);
+		$this->assertEquals(2, $exceptionCount);
 	}
 
 	public function testRating(){
-		$Rated = $this->TwigGravatar->rating($this->Url, "r");
-		$this->assertEquals($this->Url."?rating=r", $Rated);
+		$rated = $this->twigGravatar->rating($this->url, "r");
+		$this->assertEquals($this->url."?rating=r", $rated);
 	}
 
 	public function testInvalidRating(){
-		$ExceptionCount = 0;
+		$exceptionCount = 0;
 
 		try{
-			$this->TwigGravatar->rating($this->Url, "y");
+			$this->twigGravatar->rating($this->url, "y");
 		} catch (InvalidArgumentException $e){
-			$ExceptionCount++;
+			$exceptionCount++;
 			$this->assertEquals("Rating must be g,pg,r or x", $e->getMessage());
 		}
 
-		$this->assertEquals(1, $ExceptionCount);
+		$this->assertEquals(1, $exceptionCount);
 	}
 
 	public function testGenerateHash(){
-		$Hash = $this->TwigGravatar->generateHash($this->Email);
-		$this->assertEquals($this->Hash, $Hash);
+		$hash = $this->twigGravatar->generateHash($this->email);
+		$this->assertEquals($this->hash, $hash);
 	}
 
 	public function testGetName(){
-		$Name = $this->TwigGravatar->getName();
-		$this->assertEquals("TwigGravatar", $Name);
+		$name = $this->twigGravatar->getName();
+		$this->assertEquals("TwigGravatar", $name);
 	}
 }


### PR DESCRIPTION
* for `default`, `size`, `filterPrefix`, `rating`, `useHttps`
* make `filterPrefix` private
* remove default values for functions `default`, `size` and `rating`
cause they should be set via constructor now
* added tests
* use lowerCamelCase for variables in test files
* adopted readme
* improved readme:
   * fixed twig syntax issues
   * added language identifier to code blocks

This fixes #2 