### PR TITLE
Update TwigGravatar.php

### DIFF
--- a/src/TwigGravatar.php
+++ b/src/TwigGravatar.php
@@ -1,6 +1,6 @@
 <?php
 
-class TwigGravatar extends \Twig_Extension {
+class TwigGravatar extends \Twig\Extension\AbstractExtension {
 	public $baseUrl = "http://www.gravatar.com/";
 	public $httpsUrl = "https://secure.gravatar.com/";
 


### PR DESCRIPTION
Update of twig extend.
Using the "Twig_Extension" class is deprecated since Twig version 2.7, use "Twig\Extension\AbstractExtension" instead.